### PR TITLE
Skipping Mausoleum to just farm the key

### DIFF
--- a/kolbot/libs/bots/Mausoleum.js
+++ b/kolbot/libs/bots/Mausoleum.js
@@ -23,16 +23,16 @@ function Mausoleum() {
 		throw new Error("Failed to move to Mausoleum");
 	}
 
-	Attack.clearLevel(Config.ClearType);
+	//Attack.clearLevel(Config.ClearType);
 
-	if (Config.Mausoleum.ClearCrypt) {
+	/*if (Config.Mausoleum.ClearCrypt) {
 		// Crypt exit is... awkward
 		if (!(Pather.moveToExit(17, true) && Pather.moveToPreset(17, 5, 6) && Pather.moveToExit(18, true))) {
 			throw new Error("Failed to move to Crypt");
 		}
 
 		Attack.clearLevel(Config.ClearType);
-	}
+	}*/
 
 	return true;
 }


### PR DESCRIPTION
With this changes you can **kill** only **Blood Raven** to farm **Key of Terror's** skipping the mausoleum trip.
Take in consideration that you must have this settings on your character.js:
	Scripts.Mausoleum = true;
		Config.Mausoleum.KillBloodRaven = true;
		Config.Mausoleum.ClearCrypt = false;