### PR TITLE
Fixed A2 town movement to Meshif

### DIFF
--- a/kolbot/libs/common/Town.js
+++ b/kolbot/libs/common/Town.js
@@ -2094,6 +2094,27 @@ MainLoop:
 			this.initialize();
 		}
 
+		// Act 2 Meshif override -
+		// 	Fix interaction trigger with Meshif while he moves around
+		var meshif = getUnit(1, 210); 
+		
+		// Logic applies only when meshif is within range 
+		// (For instance, when we are at the portals area)
+		if (me.act === 2 && spot === NPC.Meshif && meshif) {
+			Pather.walkTo(5200, 5060);
+			
+			var prevDistance, distance; 
+			// Waits until Meshif stops walking
+			while((distance = getDistance(me, meshif)) !== prevDistance) { 
+				delay(500);
+				prevDistance = distance;
+			}
+			
+			Pather.walkTo(meshif.x, meshif.y);
+			
+			return true;
+		}
+
 		// Act 5 wp->portalspot override - ActMap.cpp crash
 		if (me.act === 5 && spot === "portalspot" && getDistance(me.x, me.y, 5113, 5068) <= 8) {
 			path = [5113, 5068, 5108, 5051, 5106, 5046, 5104, 5041, 5102, 5027, 5098, 5018];

--- a/kolbot/libs/common/Town.js
+++ b/kolbot/libs/common/Town.js
@@ -2096,12 +2096,10 @@ MainLoop:
 
 		// Act 2 Meshif override -
 		// 	Fix interaction trigger with Meshif while he moves around
-		var meshif = getUnit(1, 210); 
-		
-		// Logic applies only when meshif is within range 
-		// (For instance, when we are at the portals area)
-		if (me.act === 2 && spot === NPC.Meshif && meshif) {
-			Pather.walkTo(5200, 5060);
+		if (me.act === 2 && spot === NPC.Meshif) {
+			Pather.moveTo(5200, 5060, 0);
+			
+			var meshif = getUnit(1, 210); 
 			
 			var prevDistance, distance; 
 			// Waits until Meshif stops walking


### PR DESCRIPTION
Fixed bot town movement to Meshif in Act 2. Meshif tends to move around, making the bot unable to trigger an interaction to switch to Act 3. This fix causes the bot to wait until Meshif stops walking before approaching.